### PR TITLE
feat: implement automatic pawn promotion to queen

### DIFF
--- a/chess-backend/src/main/java/com/batuhan/chess/domain/model/Game.java
+++ b/chess-backend/src/main/java/com/batuhan/chess/domain/model/Game.java
@@ -103,7 +103,19 @@ public class Game {
 
     private void executeMove(Position start, Position end, Piece piece) {
         board.setPieceAt(start, null);
-        board.setPieceAt(end, piece);
+        if (isPromotionSituation(piece, end)) {
+            board.setPieceAt(end, new Queen(piece.getColor(), end));
+        } else {
+            board.setPieceAt(end, piece);
+        }
+    }
+
+    private boolean isPromotionSituation(Piece piece, Position end) {
+        if (piece.getType() != PieceType.PAWN) {
+            return false;
+        }
+        int promotionRank = (piece.getColor() == Color.WHITE) ? 7 : 0;
+        return end.rank() == promotionRank;
     }
 
     private void switchTurn() {

--- a/chess-backend/src/test/java/com/batuhan/chess/domain/model/GameTest.java
+++ b/chess-backend/src/test/java/com/batuhan/chess/domain/model/GameTest.java
@@ -142,4 +142,32 @@ public class GameTest {
         // Assert
         assertThat(moved).isFalse();
     }
+
+    @Test
+    @DisplayName("Pawn should automatically promote to Queen when reaching the last rank.")
+    void shouldPromotePawnToQueen() {
+        // Arrange
+        game.getBoard().clearBoard();
+
+        Position whiteKingPos = new Position(0, 0);
+        Position blackKingPos = new Position(7, 7);
+        game.getBoard().setPieceAt(whiteKingPos, new King(Color.WHITE, whiteKingPos));
+        game.getBoard().setPieceAt(blackKingPos, new King(Color.BLACK, blackKingPos));
+
+        Position start = new Position(4, 6); // e7
+        Position end = new Position(4, 7);   // e8
+        game.getBoard().setPieceAt(start, new Pawn(Color.WHITE, start));
+
+        // Act
+        boolean moved = game.makeMove(start, end);
+
+        // Assert
+        assertThat(moved).isTrue();
+        Piece promotedPiece = game.getBoard().getPiece(end)
+            .orElseThrow(() -> new AssertionError("Piece should exist at promotion square"));
+
+        assertThat(promotedPiece.getType()).isEqualTo(PieceType.QUEEN);
+        assertThat(promotedPiece.getColor()).isEqualTo(Color.WHITE);
+        assertThat(game.getBoard().getPiece(start)).isEmpty();
+    }
 }


### PR DESCRIPTION
## Overview
This PR implements the "Pawn Promotion" rule, which is a key component of Phase 3. 
When a pawn reaches the opponent's last rank (rank 7 for White, rank 0 for Black), 
it is now automatically promoted to a Queen.

## Changes
- **Game.java**: 
    - Added `isPromotionSituation` helper method to detect when a pawn reaches the final rank.
    - Updated `executeMove` logic to replace the pawn with a new `Queen` piece during promotion.
- **GameTest.java**:
    - Added `shouldPromotePawnToQueen` unit test to verify the promotion logic on an empty board (ensuring both Kings are present to satisfy domain invariants).

## Notes
- For the MVP stage, promotion is automatically set to a Queen. 
- Manual selection of other pieces (Knight, Bishop, Rook) will be implemented in future UI-integrated phases.